### PR TITLE
Refactor/deprecated-code

### DIFF
--- a/components/SidePanel/Input.tsx
+++ b/components/SidePanel/Input.tsx
@@ -14,7 +14,10 @@ export default function Input({ data, action: setData, label }: Props) {
   useEffect(() => {
     setDataBuffer(`${data}`);
   }, [data]);
-  function keyDownHandler(e: any) {
+
+  const keyDownHandler: React.KeyboardEventHandler<HTMLInputElement> = (
+    e: React.KeyboardEvent<HTMLInputElement>,
+  ) => {
     switch (e.code) {
       case "ArrowUp":
         setData(() => +dataBuffer + 1);
@@ -29,7 +32,7 @@ export default function Input({ data, action: setData, label }: Props) {
       default:
         break;
     }
-  }
+  };
 
   const setIsArrowVisible = useArrowStore((state) => state.setIsArrowVisible);
   const setX = useArrowStore((state) => state.setX);

--- a/components/SidePanel/Input.tsx
+++ b/components/SidePanel/Input.tsx
@@ -12,19 +12,22 @@ export default function Input({ data, action: setData, label }: Props) {
   const [dataBuffer, setDataBuffer] = useState("");
   const [isPLRequested, setIsPLRequested] = useState(false);
   useEffect(() => {
-    setDataBuffer(data + "");
+    setDataBuffer(`${data}`);
   }, [data]);
   function keyDownHandler(e: any) {
-    if (e.keyCode === 38) {
-      setData(() => +dataBuffer + 1);
-    } else if (e.keyCode === 40) {
-      setData(() => +dataBuffer - 1);
-    } else if (e.keyCode === 13) {
-      if (Number.isNaN(Number(dataBuffer))) {
-        setDataBuffer(data + "");
-      } else {
-        setData(() => +dataBuffer);
-      }
+    switch (e.code) {
+      case "ArrowUp":
+        setData(() => +dataBuffer + 1);
+        break;
+      case "ArrowDown":
+        setData(() => +dataBuffer - 1);
+        break;
+      case "Enter":
+        Number.isNaN(Number(dataBuffer))
+          ? setDataBuffer(`${data}`)
+          : setData(() => +dataBuffer);
+      default:
+        break;
     }
   }
 
@@ -77,7 +80,7 @@ export default function Input({ data, action: setData, label }: Props) {
         onChange={(e) => setDataBuffer(e.target.value)}
         onBlur={() =>
           Number.isNaN(Number(dataBuffer))
-            ? setDataBuffer(data + "")
+            ? setDataBuffer(`${data}`)
             : setData(() => Number(dataBuffer))
         }
         onKeyDown={keyDownHandler}


### PR DESCRIPTION
KeyboardEvent.keyCode is deprecated so I replaced it with KeyboardEvent.code.

I used `switch` instead of `if..else` and add types in `keyDownHandler()`

FIX #36