### PR TITLE
Fix: data input value converts to zero if input value empty string

### DIFF
--- a/components/SidePanel/Input.tsx
+++ b/components/SidePanel/Input.tsx
@@ -15,16 +15,19 @@ export default function Input({ data, action: setData, label }: Props) {
     setDataBuffer(data + "");
   }, [data]);
   function keyDownHandler(e: any) {
-    if (e.keyCode === 38) {
-      setData(() => +dataBuffer + 1);
-    } else if (e.keyCode === 40) {
-      setData(() => +dataBuffer - 1);
-    } else if (e.keyCode === 13) {
-      if (Number.isNaN(Number(dataBuffer))) {
-        setDataBuffer(data + "");
-      } else {
-        setData(() => +dataBuffer);
-      }
+    switch (e.code) {
+      case "ArrowUp":
+        setData(() => +dataBuffer + 1);
+        break;
+      case "ArrowDown":
+        setData(() => +dataBuffer - 1);
+        break;
+      case "Enter":
+        Number.isNaN(Number(dataBuffer))
+          ? setDataBuffer(data + "")
+          : setData(() => +dataBuffer);
+      default:
+        break;
     }
   }
 

--- a/components/SidePanel/Input.tsx
+++ b/components/SidePanel/Input.tsx
@@ -23,9 +23,7 @@ export default function Input({ data, action: setData, label }: Props) {
         setData(() => +dataBuffer - 1);
         break;
       case "Enter":
-        Number.isNaN(Number(dataBuffer))
-          ? setDataBuffer(data + "")
-          : setData(() => +dataBuffer);
+        setOrResetDataBuffer();
       default:
         break;
     }
@@ -64,6 +62,12 @@ export default function Input({ data, action: setData, label }: Props) {
     setIsArrowVisible(() => false);
   }
 
+  function setOrResetDataBuffer() {
+    return dataBuffer && !Number.isNaN(Number(dataBuffer))
+      ? setData(() => +dataBuffer)
+      : setDataBuffer(data + "");
+  }
+
   return (
     <div className="flex w-1/2 gap-x-3">
       <label
@@ -78,11 +82,7 @@ export default function Input({ data, action: setData, label }: Props) {
       <input
         value={dataBuffer}
         onChange={(e) => setDataBuffer(e.target.value)}
-        onBlur={() =>
-          Number.isNaN(Number(dataBuffer))
-            ? setDataBuffer(data + "")
-            : setData(() => Number(dataBuffer))
-        }
+        onBlur={setOrResetDataBuffer}
         onKeyDown={keyDownHandler}
         className="w-full"
         type="text"


### PR DESCRIPTION
Data inputs (width, height, radius) onblur or key down "Enter" resets to previous value if empty string.

KeyboardEvent.keyCode is deprecated so I replaced it with KeyboardEvent.code.

I used `switch` instead of `if..else..if`.

FIX 36
FIX 37