### PR TITLE
Feat: ✨ Check icon when file is downloaded/copied

### DIFF
--- a/components/ExportButton.tsx
+++ b/components/ExportButton.tsx
@@ -82,24 +82,20 @@ function SaveButton({ rootRef }: any) {
   const { Icon, setShowSecondIcon } = useIcon([SaveSVG, CheckSVG]);
   async function exportPNG() {
     if (rootRef.current !== undefined) {
-      try {
-        const canvas = await html2canvas(rootRef.current, {
-          allowTaint: true,
-          useCORS: true,
-          scale: 3,
-          backgroundColor: null,
-        });
-        const img = canvas.toDataURL("image/png", 1.0);
+      const canvas = await html2canvas(rootRef.current, {
+        allowTaint: true,
+        useCORS: true,
+        scale: 3,
+        backgroundColor: null,
+      });
+      const img = canvas.toDataURL("image/png", 1.0);
 
-        const a = document.createElement("a");
-        a.href = img;
-        a.download = "tweet.png";
-        a.click();
-        a.remove();
-        setShowSecondIcon(true);
-      } catch (error) {
-        // ? do something
-      }
+      const a = document.createElement("a");
+      a.href = img;
+      a.download = "tweet.png";
+      a.click();
+      a.remove();
+      setShowSecondIcon(true);
     }
   }
 
@@ -119,22 +115,18 @@ function CopyButton({ rootRef }: any) {
 
   async function copytoClipboard() {
     if (rootRef.current !== undefined) {
-      try {
-        const canvas = await html2canvas(rootRef.current, {
-          allowTaint: true,
-          useCORS: true,
-          scale: 3,
-          backgroundColor: null,
-        });
+      const canvas = await html2canvas(rootRef.current, {
+        allowTaint: true,
+        useCORS: true,
+        scale: 3,
+        backgroundColor: null,
+      });
 
-        canvas.toBlob((blob: any) => {
-          const data = [new ClipboardItem({ "image/png": blob })];
-          navigator.clipboard.write(data);
-        });
-        setShowSecondIcon(true);
-      } catch (error) {
-        // ? do something
-      }
+      canvas.toBlob((blob: any) => {
+        const data = [new ClipboardItem({ "image/png": blob })];
+        navigator.clipboard.write(data);
+      });
+      setShowSecondIcon(true);
     }
   }
   return (

--- a/components/ExportButton.tsx
+++ b/components/ExportButton.tsx
@@ -1,5 +1,6 @@
 import html2canvas from "html2canvas";
 import {
+  CheckIcon,
   ArrowDownTrayIcon,
   DocumentDuplicateIcon,
 } from "@heroicons/react/24/outline";
@@ -23,67 +24,8 @@ export default function ExportButton({ rootRef, className }: any) {
   );
 }
 
-const CheckSVG = () => {
-  return (
-    <svg
-      enableBackground="new 0 0 24 24"
-      viewBox="0 0 24 24"
-      xmlns="http://www.w3.org/2000/svg"
-      className="h-5 w-5"
-    >
-      <polyline
-        clip-rule="evenodd"
-        fill="none"
-        fill-rule="evenodd"
-        points="20,6 9,17 4,12 "
-        stroke="currentColor"
-        stroke-miterlimit="10"
-        stroke-width={1.5}
-      />
-    </svg>
-  );
-};
-
-const SaveSVG = () => {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      fill="none"
-      viewBox="0 0 24 24"
-      strokeWidth={1.5}
-      stroke="currentColor"
-      className="h-5 w-5"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
-      />
-    </svg>
-  );
-};
-
-const CopySVG = () => {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      fill="none"
-      viewBox="0 0 24 24"
-      strokeWidth={1.5}
-      stroke="currentColor"
-      className="h-5 w-5"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 01-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 011.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 00-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 01-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 00-3.375-3.375h-1.5a1.125 1.125 0 01-1.125-1.125v-1.5a3.375 3.375 0 00-3.375-3.375H9.75"
-      />
-    </svg>
-  );
-};
-
 function SaveButton({ rootRef }: any) {
-  const { Icon, setShowSecondIcon } = useIcon([SaveSVG, CheckSVG]);
+  const { Icon, setShowSecondIcon } = useIcon([ArrowDownTrayIcon, CheckIcon]);
   async function exportPNG() {
     if (rootRef.current !== undefined) {
       const canvas = await html2canvas(rootRef.current, {
@@ -108,14 +50,17 @@ function SaveButton({ rootRef }: any) {
       className="flex h-full w-1/2 items-center gap-x-1.5 pl-6 hover:bg-neutral-900"
       onClick={exportPNG}
     >
-      <Icon />
+      <Icon className="h-5 w-5" />
       <span>Save</span>
     </button>
   );
 }
 
 function CopyButton({ rootRef }: any) {
-  const { Icon, setShowSecondIcon } = useIcon([CopySVG, CheckSVG]);
+  const { Icon, setShowSecondIcon } = useIcon([
+    DocumentDuplicateIcon,
+    CheckIcon,
+  ]);
 
   async function copytoClipboard() {
     if (rootRef.current !== undefined) {
@@ -138,7 +83,7 @@ function CopyButton({ rootRef }: any) {
       className="flex h-full w-1/2 items-center gap-x-1.5 pl-4 hover:bg-neutral-900"
       onClick={copytoClipboard}
     >
-      <Icon />
+      <Icon className="h-5 w-5" />
       <span>Copy</span>
     </button>
   );

--- a/components/ExportButton.tsx
+++ b/components/ExportButton.tsx
@@ -7,25 +7,8 @@ import {
 import { useEffect, useState } from "react";
 
 export default function ExportButton({ rootRef, className }: any) {
-  return (
-    <div
-      className={`group flex h-full w-32 items-center justify-center overflow-hidden rounded-full bg-black text-white transition-[width] delay-300 hover:w-56 hover:delay-[0ms]  ${className}`}
-    >
-      <div className="absolute opacity-100 transition-opacity delay-200 group-hover:opacity-0 group-hover:delay-[0ms]">
-        Export
-      </div>
-      <div className="h-full w-56 opacity-0 transition-opacity duration-500 group-hover:opacity-100 group-hover:delay-150">
-        <div className="flex h-full w-full -translate-x-[62px] items-center transition-transform delay-1000 group-hover:translate-x-0 group-hover:delay-[0ms]">
-          <SaveButton rootRef={rootRef} />
-          <CopyButton rootRef={rootRef} />
-        </div>
-      </div>
-    </div>
-  );
-}
+  const [SaveIcon, setSaveIcon] = useIcon([ArrowDownTrayIcon, CheckIcon]);
 
-function SaveButton({ rootRef }: any) {
-  const { Icon, setShowSecondIcon } = useIcon([ArrowDownTrayIcon, CheckIcon]);
   async function exportPNG() {
     if (rootRef.current !== undefined) {
       const canvas = await html2canvas(rootRef.current, {
@@ -41,26 +24,11 @@ function SaveButton({ rootRef }: any) {
       a.download = "tweet.png";
       a.click();
       a.remove();
-      setShowSecondIcon(true);
+      setSaveIcon(true);
     }
   }
 
-  return (
-    <button
-      className="flex h-full w-1/2 items-center gap-x-1.5 pl-6 hover:bg-neutral-900"
-      onClick={exportPNG}
-    >
-      <Icon className="h-5 w-5" />
-      <span>Save</span>
-    </button>
-  );
-}
-
-function CopyButton({ rootRef }: any) {
-  const { Icon, setShowSecondIcon } = useIcon([
-    DocumentDuplicateIcon,
-    CheckIcon,
-  ]);
+  const [CopyIcon, setCopyIcon] = useIcon([DocumentDuplicateIcon, CheckIcon]);
 
   async function copytoClipboard() {
     if (rootRef.current !== undefined) {
@@ -75,21 +43,40 @@ function CopyButton({ rootRef }: any) {
         const data = [new ClipboardItem({ "image/png": blob })];
         navigator.clipboard.write(data);
       });
-      setShowSecondIcon(true);
+      setCopyIcon(true);
     }
   }
+
   return (
-    <button
-      className="flex h-full w-1/2 items-center gap-x-1.5 pl-4 hover:bg-neutral-900"
-      onClick={copytoClipboard}
+    <div
+      className={`group flex h-full w-32 items-center justify-center overflow-hidden rounded-full bg-black text-white transition-[width] delay-300 hover:w-56 hover:delay-[0ms]  ${className}`}
     >
-      <Icon className="h-5 w-5" />
-      <span>Copy</span>
-    </button>
+      <div className="absolute opacity-100 transition-opacity delay-200 group-hover:opacity-0 group-hover:delay-[0ms]">
+        Export
+      </div>
+      <div className="h-full w-56 opacity-0 transition-opacity duration-500 group-hover:opacity-100 group-hover:delay-150">
+        <div className="flex h-full w-full -translate-x-[62px] items-center transition-transform delay-1000 group-hover:translate-x-0 group-hover:delay-[0ms]">
+          <button
+            className="flex h-full w-1/2 items-center gap-x-1.5 pl-6 hover:bg-neutral-900"
+            onClick={exportPNG}
+          >
+            <SaveIcon className="h-5 w-5" />
+            <span>Save</span>
+          </button>
+          <button
+            className="flex h-full w-1/2 items-center gap-x-1.5 pl-4 hover:bg-neutral-900"
+            onClick={copytoClipboard}
+          >
+            <CopyIcon className="h-5 w-5" />
+            <span>Copy</span>
+          </button>
+        </div>
+      </div>
+    </div>
   );
 }
 
-function useIcon(icons: any[], time = 1000) {
+function useIcon(icons: any, time = 1000) {
   const [showSecondIcon, setShowSecondIcon] = useState(false);
 
   useEffect(() => {
@@ -100,5 +87,5 @@ function useIcon(icons: any[], time = 1000) {
     return () => tm && clearTimeout(tm);
   });
 
-  return { Icon: showSecondIcon ? icons[1] : icons[0], setShowSecondIcon };
+  return [showSecondIcon ? icons[1] : icons[0], setShowSecondIcon];
 }

--- a/components/ExportButton.tsx
+++ b/components/ExportButton.tsx
@@ -1,40 +1,7 @@
 import html2canvas from "html2canvas";
+import { useEffect, useState } from "react";
 
 export default function ExportButton({ rootRef, className }: any) {
-  async function exportPNG() {
-    if (rootRef.current !== undefined) {
-      const canvas = await html2canvas(rootRef.current, {
-        allowTaint: true,
-        useCORS: true,
-        scale: 3,
-        backgroundColor: null,
-      });
-      const img = canvas.toDataURL("image/png", 1.0);
-
-      const a = document.createElement("a");
-      a.href = img;
-      a.download = "tweet.png";
-      a.click();
-      a.remove();
-    }
-  }
-
-  async function copytoClipboard() {
-    if (rootRef.current !== undefined) {
-      const canvas = await html2canvas(rootRef.current, {
-        allowTaint: true,
-        useCORS: true,
-        scale: 3,
-        backgroundColor: null,
-      });
-
-      canvas.toBlob((blob: any) => {
-        const data = [new ClipboardItem({ "image/png": blob })];
-        navigator.clipboard.write(data);
-      });
-    }
-  }
-
   return (
     <div
       className={`group flex h-full w-32 items-center justify-center overflow-hidden rounded-full bg-black text-white transition-[width] delay-300 hover:w-56 hover:delay-[0ms]  ${className}`}
@@ -44,48 +11,153 @@ export default function ExportButton({ rootRef, className }: any) {
       </div>
       <div className="h-full w-56 opacity-0 transition-opacity duration-500 group-hover:opacity-100 group-hover:delay-150">
         <div className="flex h-full w-full -translate-x-[62px] items-center transition-transform delay-1000 group-hover:translate-x-0 group-hover:delay-[0ms]">
-          <button
-            className="flex h-full w-1/2 items-center gap-x-1.5 pl-6 hover:bg-neutral-900"
-            onClick={exportPNG}
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={1.5}
-              stroke="currentColor"
-              className="h-5 w-5"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
-              />
-            </svg>
-            <span>Save</span>
-          </button>
-          <button
-            className="flex h-full w-1/2 items-center gap-x-1.5 pl-4 hover:bg-neutral-900"
-            onClick={copytoClipboard}
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={1.5}
-              stroke="currentColor"
-              className="h-5 w-5"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 01-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 011.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 00-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 01-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 00-3.375-3.375h-1.5a1.125 1.125 0 01-1.125-1.125v-1.5a3.375 3.375 0 00-3.375-3.375H9.75"
-              />
-            </svg>
-            <span>Copy</span>
-          </button>
+          <SaveButton rootRef={rootRef} />
+          <CopyButton rootRef={rootRef} />
         </div>
       </div>
     </div>
   );
+}
+
+const CheckSVG = () => {
+  return (
+    <svg
+      enableBackground="new 0 0 24 24"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      className="h-5 w-5"
+    >
+      <polyline
+        clip-rule="evenodd"
+        fill="none"
+        fill-rule="evenodd"
+        points="20,6 9,17 4,12 "
+        stroke="currentColor"
+        stroke-miterlimit="10"
+        stroke-width={1.5}
+      />
+    </svg>
+  );
+};
+
+const SaveSVG = () => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className="h-5 w-5"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
+      />
+    </svg>
+  );
+};
+
+const CopySVG = () => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className="h-5 w-5"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 01-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 011.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 00-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 01-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 00-3.375-3.375h-1.5a1.125 1.125 0 01-1.125-1.125v-1.5a3.375 3.375 0 00-3.375-3.375H9.75"
+      />
+    </svg>
+  );
+};
+
+function SaveButton({ rootRef }: any) {
+  const { Icon, setShowSecondIcon } = useIcon([SaveSVG, CheckSVG]);
+  async function exportPNG() {
+    if (rootRef.current !== undefined) {
+      try {
+        const canvas = await html2canvas(rootRef.current, {
+          allowTaint: true,
+          useCORS: true,
+          scale: 3,
+          backgroundColor: null,
+        });
+        const img = canvas.toDataURL("image/png", 1.0);
+
+        const a = document.createElement("a");
+        a.href = img;
+        a.download = "tweet.png";
+        a.click();
+        a.remove();
+        setShowSecondIcon(true);
+      } catch (error) {
+        // ? do something
+      }
+    }
+  }
+
+  return (
+    <button
+      className="flex h-full w-1/2 items-center gap-x-1.5 pl-6 hover:bg-neutral-900"
+      onClick={exportPNG}
+    >
+      <Icon />
+      <span>Save</span>
+    </button>
+  );
+}
+
+function CopyButton({ rootRef }: any) {
+  const { Icon, setShowSecondIcon } = useIcon([CopySVG, CheckSVG]);
+
+  async function copytoClipboard() {
+    if (rootRef.current !== undefined) {
+      try {
+        const canvas = await html2canvas(rootRef.current, {
+          allowTaint: true,
+          useCORS: true,
+          scale: 3,
+          backgroundColor: null,
+        });
+
+        canvas.toBlob((blob: any) => {
+          const data = [new ClipboardItem({ "image/png": blob })];
+          navigator.clipboard.write(data);
+        });
+        setShowSecondIcon(true);
+      } catch (error) {
+        // ? do something
+      }
+    }
+  }
+  return (
+    <button
+      className="flex h-full w-1/2 items-center gap-x-1.5 pl-4 hover:bg-neutral-900"
+      onClick={copytoClipboard}
+    >
+      <Icon />
+      <span>Copy</span>
+    </button>
+  );
+}
+
+function useIcon(icons: any[], time = 1000) {
+  const [showSecondIcon, setShowSecondIcon] = useState(false);
+
+  useEffect(() => {
+    let tm: ReturnType<typeof setTimeout>;
+    if (showSecondIcon) {
+      tm = setTimeout(() => setShowSecondIcon(false), time);
+    }
+    return () => tm && clearTimeout(tm);
+  });
+
+  return { Icon: showSecondIcon ? icons[1] : icons[0], setShowSecondIcon };
 }


### PR DESCRIPTION
When img is copied or downloaded icon check will appear for 1 second instead of save/copy icon.

Introduces 5 new components, which at the moment still resides in one file `ExportButton.tsx`. 3 components for svgs and 2 for each action (save/copy) and `useIcon()` hook.
Probably it would be better to move new components somewhere else at least SVG components.

FIX #32 