### PR TITLE
refactor: memoize functions used as dependencies on useEffect hooks

### DIFF
--- a/components/TweetCard/CardResizable.tsx
+++ b/components/TweetCard/CardResizable.tsx
@@ -1,7 +1,7 @@
 import { useCardStore } from "../../store/card";
 import { Resizable } from "re-resizable";
 import CardOuter from "./CardOuter";
-import { useEffect, useState } from "react";
+import {useCallback, useEffect, useState} from "react";
 import { MIN_ALLOWED_HEIGHT, MIN_ALLOWED_WIDTH } from "../../store/constants";
 
 
@@ -11,8 +11,8 @@ export default function ResizableTweet({ rootRef }: any) {
 
   const cardWidth = useCardStore((state) => state.width);
   const cardHeight = useCardStore((state) => state.height);
-  const setWidth = useCardStore((state) => state.setWidth);
-  const setHeight = useCardStore((state) => state.setHeight);
+  const setWidth = useCardStore(useCallback((state) => state.setWidth, []));
+  const setHeight = useCardStore(useCallback((state) => state.setHeight, []));
   function resizeHandler(e: any, dir: any) {
     switch (dir) {
       case "left":
@@ -58,11 +58,11 @@ export default function ResizableTweet({ rootRef }: any) {
 
   useEffect(() => {
     setWidth(() => widthBuffer);
-  }, [widthBuffer]);
+  }, [setWidth, widthBuffer]);
 
   useEffect(() => {
     setHeight(() => heightBuffer);
-  }, [heightBuffer]);
+  }, [setHeight, heightBuffer]);
 
   return (
     <Resizable

--- a/components/TweetCard/index.tsx
+++ b/components/TweetCard/index.tsx
@@ -1,10 +1,10 @@
 import { usePanStore } from "../../store/pan";
-import { useEffect } from "react";
+import {useCallback, useEffect} from "react";
 import CardResizable from "./CardResizable";
 
 export default function TweetCard({ rootRef }: any) {
   const isSpaceDown = usePanStore((state) => state.isSpaceDown);
-  const setIsSpaceDown = usePanStore((state) => state.setIsSpaceDown);
+  const setIsSpaceDown = usePanStore(useCallback((state) => state.setIsSpaceDown, []));
   const isMouseDown = usePanStore((state) => state.isMouseDown);
   const setIsMouseDown = usePanStore((state) => state.setIsMouseDown);
   const moveBy = usePanStore((state) => state.moveBy);
@@ -22,7 +22,7 @@ export default function TweetCard({ rootRef }: any) {
         setIsSpaceDown(() => false);
       }
     });
-  }, []);
+  }, [setIsSpaceDown]);
 
   function mouseDownHandler() {
     setIsMouseDown(() => true);


### PR DESCRIPTION
Memoize functions used as dependencies on certain useEffect hooks using useCallback. This solves lint's warning about missing dependencies.

**Changes**

- [x] Memoize  CardResizeable.tsx setWidth and setHeight then passed it as dependency of useEffect.
- [x] Memoize TweetCard setIsSpaceDown then passed it as a dependency of useEffect.

**Screenshots**
![image](https://user-images.githubusercontent.com/53674742/194822329-1d130b9b-7e1e-4393-a7cf-298eae2b8aed.png)
