### PR TITLE
fix: resolve error thrown when fetch tweets due to destructuring commit

### DIFF
--- a/components/Header/Input.tsx
+++ b/components/Header/Input.tsx
@@ -16,11 +16,10 @@ export default function Input() {
       body: JSON.stringify({ tweetUrl: url }),
     });
 
-    const dataObj = await res.json();
-    const { includes, data } = dataObj;
+    const { includes, data } = await res.json();
 
     setTweetInfo(() => ({
-      profile_image_url: data.includes.users[0].profile_image_url.replace(
+      profile_image_url: includes.users[0].profile_image_url.replace(
         "_normal",
         "",
       ),


### PR DESCRIPTION
Resolves the error thrown when fetching tweets caused by incorrect destructing on this [commit](https://github.com/subhoghoshX/laureate/commit/602e1062ecbcee4591b6907b27106f9cb1992b9f)

![image](https://user-images.githubusercontent.com/53674742/194828745-ce1218be-7414-4919-b840-88147a8ab21b.png)
