### PR TITLE
feat: show toast error message on tweet fetching fail

### DIFF
--- a/components/Header/Input.tsx
+++ b/components/Header/Input.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useTweetStore } from "../../store/tweet";
+import toast from "react-hot-toast";
 
 export default function Input() {
   const [url, setUrl] = useState("");
@@ -16,20 +17,22 @@ export default function Input() {
       body: JSON.stringify({ tweetUrl: url }),
     });
 
-    const { includes, data } = await res.json();
-
-    setTweetInfo(() => ({
-      profile_image_url: includes.users[0].profile_image_url.replace(
-        "_normal",
-        "",
-      ),
-      name: includes.users[0].name,
-      username: includes.users[0].username,
-      text: data.text,
-      retweet_count: data.public_metrics.retweet_count,
-      reply_count: data.public_metrics.reply_count,
-      like_count: data.public_metrics.like_count,
-    }));
+    res.json()
+      .then(({includes, data}) => {
+        setTweetInfo(() => ({
+          profile_image_url: includes.users[0].profile_image_url.replace(
+              "_normal",
+              "",
+          ),
+          name: includes.users[0].name,
+          username: includes.users[0].username,
+          text: data.text,
+          retweet_count: data.public_metrics.retweet_count,
+          reply_count: data.public_metrics.reply_count,
+          like_count: data.public_metrics.like_count,
+        }));
+      })
+      .catch(() => toast.error("Error encountered while fetching tweet"));
   }
 
   return (

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "re-resizable": "^6.9.9",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-hot-toast": "^2.4.0",
     "zustand": "^4.1.1"
   },
   "devDependencies": {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,8 +1,14 @@
 import "../styles/globals.css";
 import type { AppProps } from "next/app";
+import {Toaster} from "react-hot-toast";
 
 function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  return (
+      <>
+        <Component {...pageProps} />
+        <Toaster/>
+      </>
+  )
 }
 
 export default MyApp;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1548,6 +1548,11 @@ globby@^11.1.0:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
+goober@^2.1.10:
+  version "2.1.11"
+  resolved "https://registry.yarnpkg.com/goober/-/goober-2.1.11.tgz#bbd71f90d2df725397340f808dbe7acc3118e610"
+  integrity sha512-5SS2lmxbhqH0u9ABEWq7WPU69a4i2pYcHeCxqaNq6Cw3mnrF0ghWNM4tEGid4dKy8XNIAUbuThuozDHHKJVh3A==
+
 graceful-fs@^4.1.6, graceful-fs@^4.2.0:
   version "4.2.10"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
@@ -2444,6 +2449,13 @@ react-dom@18.2.0:
   dependencies:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
+
+react-hot-toast@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/react-hot-toast/-/react-hot-toast-2.4.0.tgz#b91e7a4c1b6e3068fc599d3d83b4fb48668ae51d"
+  integrity sha512-qnnVbXropKuwUpriVVosgo8QrB+IaPJCpL8oBI6Ov84uvHZ5QQcTp2qg6ku2wNfgJl6rlQXJIQU5q+5lmPOutA==
+  dependencies:
+    goober "^2.1.10"
 
 react-is@^16.13.1:
   version "16.13.1"


### PR DESCRIPTION
Fixes #55 to elegantly handle invalid URL and other errors thrown when fetching tweets.

**Changes**

- [x] Add `react-hot-toast`.
- [x] Show error toast message on failure.
- [x] Change `res.json()` to a non-blocking operation by handling it as Promise.