### PR TITLE
#issue68 => masterghost2002:added responsiveness for mobile in header

### DIFF
--- a/components/Header/Input.tsx
+++ b/components/Header/Input.tsx
@@ -37,7 +37,7 @@ export default function Input() {
   }
 
   return (
-    <form className="relative ml-auto flex w-1/2" onSubmit={handleSumbit}>
+    <form className="relative ml-auto flex w-full md:w-1/2" onSubmit={handleSumbit}>
       <input
         className="w-full rounded-full bg-slate-200 px-6 py-2.5 pr-16 text-sm ring-blue-400 focus:outline-none focus:ring-2 dark:bg-[#3c3c3c] dark:text-white dark:placeholder-neutral-400"
         type="text"

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -7,14 +7,42 @@ import Logo from "./Logo";
 interface Props {
   setIsPanelOpen: Dispatch<SetStateAction<boolean>>;
 }
-
+const HeaderStyleLargeScreen = ({ setIsPanelOpen }: Props) => {
+  return <div
+    className="hidden md:flex gap-4 items-center justify-between"
+  >
+    <Logo />
+    <Input />
+    <Info/>
+    <ButtonGroup
+      setIsPanelOpen={setIsPanelOpen}
+    />
+  </div>
+}
+const HeaderStyleMobile = ({ setIsPanelOpen }: Props) => {
+  return <div
+    className="md:hidden flex flex-col gap-4 items-center justify-between"
+  >
+    <div
+      className="flex justify-between gap-x-4 items-center w-full h-10"
+    >
+      <Logo />
+      <ButtonGroup
+        setIsPanelOpen={setIsPanelOpen}
+      />
+    </div>
+    <Input />
+  </div>
+}
 export default function Header({ setIsPanelOpen }: Props) {
   return (
-    <header className="flex items-center justify-between gap-x-4 bg-white px-4 py-2 shadow dark:bg-[#2c2c2c]">
-      <Logo />
-      <Input />
-      <Info />
-      <ButtonGroup setIsPanelOpen={setIsPanelOpen} />
+    <header className="bg-white px-4 py-2 shadow dark:bg-[#2c2c2c]">
+      <HeaderStyleLargeScreen
+        setIsPanelOpen={setIsPanelOpen}
+      />
+      <HeaderStyleMobile
+        setIsPanelOpen={setIsPanelOpen}
+      />
     </header>
   );
 }


### PR DESCRIPTION
Two components have been developed for the header: HeaderStyleLargeScreen and HeaderStyleMobile. The HeaderStyleLargeScreen component remains hidden until the md breakpoint is reached, while the HeaderStyleMobile component is set to hidden at the md breakpoint.Also, the width of the Input (Search for tweet) is set to full below md.
Preview:

https://github.com/subhoghoshX/laureate/assets/55751461/4510a62f-cc66-4b35-97b9-165a1c2f56c9

